### PR TITLE
feat: support page level cache for reading

### DIFF
--- a/parquet/Cargo.toml
+++ b/parquet/Cargo.toml
@@ -48,6 +48,7 @@ arrow-ipc = { workspace = true, optional = true }
 object_store = { version = "0.12.0", default-features = false, optional = true }
 
 bytes = { version = "1.1", default-features = false, features = ["std"] }
+dashmap = { version = "6.0", default-features = false }
 thrift = { version = "0.17", default-features = false }
 snap = { version = "1.0", default-features = false, optional = true }
 brotli = { version = "8.0", default-features = false, features = ["std"], optional = true }

--- a/parquet/src/arrow/async_reader/mod.rs
+++ b/parquet/src/arrow/async_reader/mod.rs
@@ -1116,7 +1116,7 @@ impl RowGroups for InMemoryRowGroup<'_> {
                     i,
                     self.metadata,
                     column_chunk_metadata,
-                )?;
+                )?.set_cache_context_metadata(self.row_group_idx, i, column_chunk_metadata, self.metadata);
 
                 let page_reader: Box<dyn PageReader> = Box::new(page_reader);
 

--- a/parquet/src/file/mod.rs
+++ b/parquet/src/file/mod.rs
@@ -100,6 +100,7 @@
 #[cfg(feature = "encryption")]
 pub mod column_crypto_metadata;
 pub mod metadata;
+pub mod page_cache;
 pub mod page_encoding_stats;
 pub mod page_index;
 pub mod properties;

--- a/parquet/src/file/page_cache.rs
+++ b/parquet/src/file/page_cache.rs
@@ -1,0 +1,188 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+//! Page-level cache for storing decompressed pages to avoid redundant I/O and decompression
+
+use crate::column::page::Page;
+use dashmap::DashMap;
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::Arc;
+use std::sync::Mutex;
+use std::collections::VecDeque;
+
+/// Cache key that uniquely identifies a page within a file
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct PageCacheKey {
+    /// Unique file identifier (derived from UUID or other unique metadata)
+    pub file_id: u64,
+    /// Row group index within the file
+    pub rg_idx: usize,
+    /// Column index within the row group  
+    pub column_idx: usize,
+    /// Page offset within the file
+    pub page_offset: u64,
+}
+
+impl PageCacheKey {
+    pub fn new(file_id: u64, rg_idx: usize, column_idx: usize, page_offset: u64) -> Self {
+        Self {
+            file_id,
+            rg_idx,
+            column_idx, 
+            page_offset,
+        }
+    }
+}
+
+pub struct PageCache {
+    map: DashMap<PageCacheKey, (Arc<Page>, bool)>, // (page, is_protected)
+    probationary_max: usize,
+    protected_max: usize,
+
+    probationary: Mutex<VecDeque<PageCacheKey>>,
+    protected: Mutex<VecDeque<PageCacheKey>>,
+}
+
+impl PageCache {
+    /// `probationary_ratio` in 0.0..1.0
+    pub fn new(max_pages: usize, probationary_ratio: f64) -> Self {
+        let probationary_max = ((max_pages as f64) * probationary_ratio).ceil() as usize;
+        let protected_max = max_pages - probationary_max;
+        Self {
+            map: DashMap::new(),
+            probationary_max,
+            protected_max,
+            probationary: Mutex::new(VecDeque::new()),
+            protected: Mutex::new(VecDeque::new()),
+        }
+    }
+
+    pub fn get(&self, key: &PageCacheKey) -> Option<Arc<Page>> {
+        if let Some(mut entry) = self.map.get_mut(key) {
+            let (page, is_protected) = &mut *entry;
+            let page_clone = page.clone();
+
+            if !*is_protected {
+                // Promote to protected
+                *is_protected = true;
+
+                let mut prob = self.probationary.lock().unwrap();
+                prob.retain(|k| k != key);
+                drop(prob);
+
+                let mut prot = self.protected.lock().unwrap();
+                prot.retain(|k| k != key);
+                prot.push_back(key.clone());
+                drop(prot);
+
+                // Release the DashMap entry before calling evict_if_needed to avoid deadlock
+                drop(entry);
+                // Ensure protected does not exceed limit
+                self.evict_if_needed();
+            } else {
+                // Refresh protected LRU
+                let mut prot = self.protected.lock().unwrap();
+                prot.retain(|k| k != key);
+                prot.push_back(key.clone());
+            }
+
+            Some(page_clone)
+        } else {
+            None
+        }
+    }
+
+    pub fn put(&self, key: PageCacheKey, page: Arc<Page>) {
+        if self.map.contains_key(&key) {
+            // Reset to probationary
+            self.map.insert(key.clone(), (page, false));
+            {
+                let mut prob = self.probationary.lock().unwrap();
+                prob.retain(|k| k != &key);
+                prob.push_back(key.clone());
+            }
+            // Remove from protected if it was there
+            {
+                let mut prot = self.protected.lock().unwrap();
+                prot.retain(|k| k != &key);
+            }
+            self.evict_if_needed();
+            return;
+        }
+
+        // Insert into probationary
+        self.map.insert(key.clone(), (page, false));
+        {
+            let mut prob = self.probationary.lock().unwrap();
+            prob.retain(|k| k != &key);
+            prob.push_back(key);
+        }
+
+        self.evict_if_needed();
+    }
+
+    /// Evict pages to maintain probationary/protected size ratios
+    fn evict_if_needed(&self) {
+        // Evict from probationary first
+        let mut prob = self.probationary.lock().unwrap();
+        while prob.len() > self.probationary_max {
+            if let Some(oldest) = prob.pop_front() {
+                self.map.remove(&oldest);
+            }
+        }
+        drop(prob);
+
+        // Evict from protected if necessary
+        let mut prot = self.protected.lock().unwrap();
+        while prot.len() > self.protected_max {
+            if let Some(oldest) = prot.pop_front() {
+                self.map.remove(&oldest);
+            }
+        }
+    }
+
+    pub fn size(&self) -> usize {
+        self.map.len()
+    }
+
+}
+
+/// Global page cache instance
+pub static PAGE_CACHE: std::sync::OnceLock<PageCache> = std::sync::OnceLock::new();
+
+/// Initialize the global page cache with default parameters
+pub fn init_page_cache_default() -> &'static PageCache {
+    PAGE_CACHE.get_or_init(|| {
+        PageCache::new(100, 0.25)
+    })
+}
+
+/// Get a page from the global cache
+pub fn get_cached_page(key: &PageCacheKey) -> Option<Arc<Page>> {
+    let cache = PAGE_CACHE.get_or_init(|| {
+        PageCache::new(100, 0.25)
+    });
+    cache.get(key)
+}
+
+/// Store a page in the global cache
+pub fn store_cached_page(key: PageCacheKey, page: Arc<Page>) {
+    let cache = PAGE_CACHE.get_or_init(|| {
+        PageCache::new(100, 0.25)
+    });
+    cache.put(key, page)
+}


### PR DESCRIPTION
This is a preliminary pr. The benchmark result is from this version.
However it cannot pass all tests. Run `cargo test -p parquet --features=arrow arrow_reader`, and 4 tests will fail.
The reason is that these tests run concurrently, but the `PAGE_CACHE` is a global static. It meat the order problem of decoding dictionary, and reading the same file, so the test will fail.
If other test fail, add a simple `if file_id != 0` before call `decode_page_cached` to abandon sync reader calling this, and should work.

The biggest problem is whether we can use a global static or not.
